### PR TITLE
fix required and optional fields for create_changeset in Task

### DIFF
--- a/priv/repo/migrations/20160324115342_create_task.exs
+++ b/priv/repo/migrations/20160324115342_create_task.exs
@@ -6,7 +6,7 @@ defmodule Fyler.Repo.Migrations.CreateTask do
 
     create table(:tasks, primary_key: false) do
       add :id, :uuid, primary_key: true, default: fragment("uuid_generate_v4()")
-      add :status, :string, default: "idle"
+      add :status, :string
       add :type, :string
       add :category, :string
       add :source, :string

--- a/test/controllers/api/tasks_controller_test.exs
+++ b/test/controllers/api/tasks_controller_test.exs
@@ -55,7 +55,7 @@ defmodule Fyler.Api.TasksControllerTest do
   end
 
   test "GET #show", %{auth_conn: auth_conn} do
-    task = Fyler.Repo.insert! Fyler.Task.create_changeset(%Fyler.Task{}, %{source: "http://foo.example.com/files/foo.avi", type: "video"})
+    task = Fyler.Repo.insert! Fyler.Task.create_changeset(%Fyler.Task{}, %{project_id: create(:project).id, source: "http://foo.example.com/files/foo.avi", type: "video"})
     response = get auth_conn, "/api/tasks/#{task.id}"
     id = task.id
     assert %{"task" => %{"id" => ^id, "type" => "video", "category" => "ffmpeg"}} = json_response(response, 200)
@@ -63,7 +63,7 @@ defmodule Fyler.Api.TasksControllerTest do
 
   @tag :not_auth
   test "GET #show (without auth)" do
-    task = Fyler.Repo.insert! Fyler.Task.create_changeset(%Fyler.Task{}, %{source: "http://foo.example.com/files/foo.avi", type: "video"})
+    task = Fyler.Repo.insert! Fyler.Task.create_changeset(%Fyler.Task{}, %{project_id: create(:project).id, source: "http://foo.example.com/files/foo.avi", type: "video"})
     response = get conn(), "/api/tasks/#{task.id}"
     assert %{"errors" => "bad_token"} = json_response(response, 403)
   end

--- a/test/controllers/tasks_controller_test.exs
+++ b/test/controllers/tasks_controller_test.exs
@@ -8,7 +8,7 @@ defmodule Fyler.TasksControllerTest do
   end
 
   test "GET #index with pagination", %{auth_conn: auth_conn} do
-    Fyler.Repo.insert! Fyler.Task.create_changeset(%Fyler.Task{}, %{source: "http://foo.example.com/files/foo.avi", type: "video"})
+    Fyler.Repo.insert! Fyler.Task.create_changeset(%Fyler.Task{}, %{project_id: create(:project).id, source: "http://foo.example.com/files/foo.avi", type: "video"})
     response = get auth_conn, "/admin/tasks"
 
     pagination = %{"page_number" => 1, "page_size" => 20, "total_entries" => 1, "total_pages" => 1}
@@ -16,9 +16,9 @@ defmodule Fyler.TasksControllerTest do
   end
 
   test "GET #index filtered by category", %{auth_conn: auth_conn} do
-    Fyler.Repo.insert! Fyler.Task.create_changeset(%Fyler.Task{}, %{source: "http://foo.example.com/files/foo.avi", type: "video"})    
-    Fyler.Repo.insert! Fyler.Task.create_changeset(%Fyler.Task{}, %{source: "http://foo.example.com/files/bar.pdf", type: "pdf"})    
-    Fyler.Repo.insert! Fyler.Task.create_changeset(%Fyler.Task{}, %{source: "http://foo.example.com/files/foo.pdf", type: "pdf"})
+    Fyler.Repo.insert! Fyler.Task.create_changeset(%Fyler.Task{}, %{project_id: create(:project).id, source: "http://foo.example.com/files/foo.avi", type: "video"})    
+    Fyler.Repo.insert! Fyler.Task.create_changeset(%Fyler.Task{}, %{project_id: create(:project).id, source: "http://foo.example.com/files/bar.pdf", type: "pdf"})    
+    Fyler.Repo.insert! Fyler.Task.create_changeset(%Fyler.Task{}, %{project_id: create(:project).id, source: "http://foo.example.com/files/foo.pdf", type: "pdf"})
 
     response = get auth_conn, "/admin/tasks", %{category: "ffmpeg"}
     %{"tasks" => tasks, "pagination" => _pagination} = json_response(response, 200)
@@ -31,9 +31,9 @@ defmodule Fyler.TasksControllerTest do
   end
 
   test "GET #index filtered by category and type", %{auth_conn: auth_conn} do
-    Fyler.Repo.insert! Fyler.Task.create_changeset(%Fyler.Task{}, %{source: "http://foo.example.com/files/foo.avi", type: "video"})    
-    Fyler.Repo.insert! Fyler.Task.create_changeset(%Fyler.Task{}, %{source: "http://foo.example.com/files/bar.pdf", type: "pdf"})    
-    Fyler.Repo.insert! Fyler.Task.create_changeset(%Fyler.Task{}, %{source: "http://foo.example.com/files/foo.pdf", type: "pdf"})
+    Fyler.Repo.insert! Fyler.Task.create_changeset(%Fyler.Task{}, %{project_id: create(:project).id, source: "http://foo.example.com/files/foo.avi", type: "video"})    
+    Fyler.Repo.insert! Fyler.Task.create_changeset(%Fyler.Task{}, %{project_id: create(:project).id, source: "http://foo.example.com/files/bar.pdf", type: "pdf"})    
+    Fyler.Repo.insert! Fyler.Task.create_changeset(%Fyler.Task{}, %{project_id: create(:project).id, source: "http://foo.example.com/files/foo.pdf", type: "pdf"})
 
     response = get auth_conn, "/admin/tasks", %{category: "doc", type: "pdf"}
     %{"tasks" => tasks, "pagination" => _pagination} = json_response(response, 200)
@@ -41,13 +41,12 @@ defmodule Fyler.TasksControllerTest do
   end
 
   test "GET index with order", %{auth_conn: auth_conn} do
-    Fyler.Repo.insert! Fyler.Task.create_changeset(%Fyler.Task{}, %{source: "http://foo.example.com/files/foo.avi", type: "video", download_time: 123})    
-    Fyler.Repo.insert! Fyler.Task.create_changeset(%Fyler.Task{}, %{source: "http://foo.example.com/files/bar.pdf", type: "pdf", download_time: 456})    
-    Fyler.Repo.insert! Fyler.Task.create_changeset(%Fyler.Task{}, %{source: "http://foo.example.com/files/foo.pdf", type: "pdf", download_time: 871})
-    
-    response = get auth_conn, "/admin/tasks", %{"sort" => %{"download_time" => "desc"}}
+    t1 = Fyler.Repo.insert! Fyler.Task.create_changeset(%Fyler.Task{}, %{project_id: create(:project).id, source: "http://foo.example.com/files/foo.avi", type: "video", iserted_at: Ecto.DateTime.cast!("2016-01-01 10:00:00")})
+    Fyler.Repo.insert! Fyler.Task.create_changeset(%Fyler.Task{}, %{project_id: create(:project).id, source: "http://foo.example.com/files/bar.pdf", type: "pdf", iserted_at: Ecto.DateTime.cast!("2016-01-01 10:20:00")})
+    Fyler.Repo.insert! Fyler.Task.create_changeset(%Fyler.Task{}, %{project_id: create(:project).id, source: "http://foo.example.com/files/foo.pdf", type: "pdf", iserted_at: Ecto.DateTime.cast!("2016-01-01 10:40:00")})
+
+    response = get auth_conn, "/admin/tasks", %{"sort" => %{"inserted_at" => "asc"}}
     %{"tasks" => tasks, "pagination" => _pagination} = json_response(response, 200)
-    assert List.first(tasks)["download_time"] == 871
-    assert List.last(tasks)["download_time"] == 123
+    assert List.first(tasks)["id"] == t1.id
   end
 end

--- a/test/models/task_test.exs
+++ b/test/models/task_test.exs
@@ -3,7 +3,13 @@ defmodule Fyler.TaskTest do
 
   alias Fyler.Task
 
-  @valid_create_attrs %{source: "http://foo.example.com/files/foo.avi", type: "video"}
+  @valid_create_attrs %{project_id: create(:project).id, source: "http://foo.example.com/files/foo.avi", type: "video"}
+
+  test "#insert creates with default status" do
+    changeset = Task.create_changeset(%Task{}, @valid_create_attrs)
+    task = Fyler.Repo.insert!(changeset)
+    assert task.status == "idle"
+  end
 
   test "#create_changeset with valid attributes" do
     changeset = Task.create_changeset(%Task{}, @valid_create_attrs)
@@ -17,7 +23,7 @@ defmodule Fyler.TaskTest do
   end
 
   test "#create_changeset with pipe type" do
-    params = %{source: "http://foo.example.com/files/foo.avi", type: "pipe", category: "document"}
+    params = %{project_id: create(:project).id, source: "http://foo.example.com/files/foo.avi", type: "pipe", category: "document"}
     changeset = Task.create_changeset(%Task{}, params)
     assert changeset.valid?
     assert changeset.changes[:category] == "document"
@@ -25,35 +31,42 @@ defmodule Fyler.TaskTest do
   end
 
   test "#create_changeset with pipe (without category)" do
-    params = %{source: "http://foo.example.com/files/foo.avi", type: "pipe"}
+    params = %{project_id: create(:project).id, source: "http://foo.example.com/files/foo.avi", type: "pipe"}
     changeset = Task.create_changeset(%Task{}, params)
     refute changeset.valid?
     assert changeset.errors == [category: "can't be blank"]
   end
 
   test "#create_changeset without type" do
-    params = %{source: "http://foo.example.com/files/foo.avi"}
+    params = %{project_id: create(:project).id, source: "http://foo.example.com/files/foo.avi"}
     changeset = Task.create_changeset(%Task{}, params)
     refute changeset.valid?
     assert changeset.errors == [type: "can't be blank", category: "can't be blank"]
   end
 
+  test "#create_changeset without project" do
+    params = %{source: "http://foo.example.com/files/foo.avi", type: "pipe", category: "document"}
+    changeset = Task.create_changeset(%Task{}, params)
+    refute changeset.valid?
+    assert changeset.errors == [project_id: "can't be blank"]
+  end
+
   test "#create_changeset when type not inclusion" do
-    params = %{source: "http://foo.example.com/files/foo.avi", type: "foo"}
+    params = %{project_id: create(:project).id, source: "http://foo.example.com/files/foo.avi", type: "foo"}
     changeset = Task.create_changeset(%Task{}, params)
     refute changeset.valid?
     assert changeset.errors == [type: "is invalid"]
   end
 
   test "#create_changeset when URL is invalid" do
-    params = %{source: "foo/bar", type: "video"}
+    params = %{project_id: create(:project).id, source: "foo/bar", type: "video"}
     changeset = Task.create_changeset(%Task{}, params)
     refute changeset.valid?
     assert changeset.errors == [source: "has invalid format"]
   end
 
   test "#create_changeset when URL is s3" do
-    params = %{source: "s3://foo.example.com/files/foo.avi", type: "video"}
+    params = %{project_id: create(:project).id, source: "s3://foo.example.com/files/foo.avi", type: "video"}
     changeset = Task.create_changeset(%Task{}, params)
     assert changeset.valid?
   end

--- a/web/controllers/api/tasks_controller.ex
+++ b/web/controllers/api/tasks_controller.ex
@@ -8,8 +8,7 @@ defmodule Fyler.Api.TasksController do
   end
 
   def create(conn, %{"task" => params}) do
-    changeset = Task.create_changeset(%Task{}, params)
-    
+    changeset = Task.create_changeset(%Task{}, Map.merge(params, %{project_id: project_id(conn)}))
     case Repo.insert(changeset) do
       {:ok, task} ->
         render conn, "create.json", data: task
@@ -18,5 +17,9 @@ defmodule Fyler.Api.TasksController do
         |> put_status(403)
         |> render("error.json", changeset: changeset)
     end
+  end
+
+  defp project_id(conn) do
+    conn.assigns[:current_project_id]
   end
 end

--- a/web/models/project.ex
+++ b/web/models/project.ex
@@ -6,6 +6,7 @@ defmodule Fyler.Project do
     field :api_key, :string
     field :settings, :map
 
+    has_many :tasks, Fyler.Task
     timestamps
   end
 


### PR DESCRIPTION
Пробежался, поправил required / optional fields.
Со статусом, почему-то не проставляется default  из миграций. Пока перенес установку статуса в create_changeset. Мб в Ecto 2 поправят;
- валидация на project_id.

Вроде это все поля поля как я понял. Data, как я понял по докам, будет обрабатываться перед помещением в очередь. А output поле судя по карточке будет лежать в data.
